### PR TITLE
Fix Php8 notices and related bug

### DIFF
--- a/AkismetPlugin.inc.php
+++ b/AkismetPlugin.inc.php
@@ -69,7 +69,7 @@ class AkismetPlugin extends GenericPlugin {
 	 * @see DAO::getAddtionalFieldNames
 	 */
 	function addAkismetSetting($hookname, $args) {
-		$fields =& $args[1];
+		$fields = $args[1];
 		$fields = array_merge($fields, array($this->getName()."::".$this->dataUserSetting));
 		return false;
 	}
@@ -120,7 +120,7 @@ class AkismetPlugin extends GenericPlugin {
 				if (!Validation::isSiteAdmin()) {
 					return new JSONMessage(false);
 				}
-				$templateMgr =& TemplateManager::getManager();
+				$templateMgr = TemplateManager::getManager();
 				$templateMgr->register_function('plugin_url', array(&$this, 'smartyPluginUrl'));
 
 				$this->import('AkismetSettingsForm');
@@ -144,7 +144,7 @@ class AkismetPlugin extends GenericPlugin {
 	 * @see Form::validate()
 	 */
 	function checkAkismet($hookName, $args) {
-		$request = Application::getRequest();
+		$request = Application::get()->getRequest();
 		$context = $request->getContext();
 		$locales = array();
 		if (!$context) {
@@ -177,7 +177,8 @@ class AkismetPlugin extends GenericPlugin {
 		$iso639_1 = array();
 		foreach (array_keys($locales) as $locale) {
 			// Our locale names are of the form ISO639-1 + "_" + ISO3166-1 
-			$iso639_1[] = array_pop(explode('_', $locale, 1));
+			$localeList=explode('_', $locale);
+			$iso639_1[] = array_pop($localeList);
 		}
 		$data = array_merge(
 			$data,
@@ -200,8 +201,8 @@ class AkismetPlugin extends GenericPlugin {
 		} else if ($hookName === 'registrationform::validate') {
 			// remember this successful check in the session
 			// we'll store it as a user setting on form execution
-			$sessionManager =& SessionManager::getManager();
-			$session =& $sessionManager->getUserSession();
+			$sessionManager = SessionManager::getManager();
+			$session = $sessionManager->getUserSession();
 			$session->setSessionVar($this->getName()."::".$this->dataUserSetting, $data);
 		}
 		// returning false allows processing to continue
@@ -246,8 +247,8 @@ class AkismetPlugin extends GenericPlugin {
 		switch ($hookName) {
 			case 'registrationform::execute':
 				// The original data can be found in the user session, per checkAkismet()
-				$sessionManager =& SessionManager::getManager();
-				$session =& $sessionManager->getUserSession();
+				$sessionManager = SessionManager::getManager();
+				$session = $sessionManager->getUserSession();
 				$data = $session->getSessionVar($this->getName()."::".$this->dataUserSetting);
 				// Prior to 3.1.2 the user was passed as an argument
 				$user = $args[1];
@@ -257,7 +258,7 @@ class AkismetPlugin extends GenericPlugin {
 					$username = $form->getData('username');
 					$userDao = DAORegistry::getDAO('UserDAO');
 					$settingName = $this->getName()."::".$this->dataUserSetting;
-					$session->unsetSessionVar($this->getName()."::".settingName);
+					$session->unsetSessionVar($this->getName()."::".$settingName);
 					// On shutdown, persist the Akismet setting to the new user account. (https://github.com/pkp/pkp-lib/issues/4601)
 					register_shutdown_function(function() use ($username, $userDao, $settingName, $data) {
 						$user = $userDao->getByUsername($username);
@@ -415,8 +416,8 @@ class AkismetPlugin extends GenericPlugin {
 		// build the Akismet HTTP request
 		$host = $akismetKey.'.rest.akismet.com';
 		$path = '/1.1/' . ($flag ? 'submit-spam' : 'comment-check');
-		$versionDao =& DAORegistry::getDAO('VersionDAO');
-		$dbVersion =& $versionDao->getCurrentVersion();
+		$versionDao = DAORegistry::getDAO('VersionDAO');
+		$dbVersion = $versionDao->getCurrentVersion();
 		$ua = $dbVersion->getProduct().' '.$dbVersion->getVersionString().' | Akismet/3.1.7';
 		$httpClient = Application::get()->getHttpClient();
 		try {$response = $httpClient->request(

--- a/AkismetPlugin.inc.php
+++ b/AkismetPlugin.inc.php
@@ -13,7 +13,7 @@
  */
 
 import('lib.pkp.classes.plugins.GenericPlugin');
-
+use PKP\i18n;
 class AkismetPlugin extends GenericPlugin {
 	
 	/**
@@ -177,8 +177,8 @@ class AkismetPlugin extends GenericPlugin {
 		$iso639_1 = array();
 		foreach (array_keys($locales) as $locale) {
 			// Our locale names are of the form ISO639-1 + "_" + ISO3166-1 
-			$localeList=explode('_', $locale);
-			$iso639_1[] = $localeList[0];
+			// Store the first part of the locale
+			$iso639_1[] = PKPLocale::getIso1FromLocale($locale);
 		}
 		$data = array_merge(
 			$data,

--- a/AkismetPlugin.inc.php
+++ b/AkismetPlugin.inc.php
@@ -178,7 +178,7 @@ class AkismetPlugin extends GenericPlugin {
 		foreach (array_keys($locales) as $locale) {
 			// Our locale names are of the form ISO639-1 + "_" + ISO3166-1 
 			$localeList=explode('_', $locale);
-			$iso639_1[] = array_pop($localeList);
+			$iso639_1[] = $localeList[0];
 		}
 		$data = array_merge(
 			$data,

--- a/AkismetPlugin.inc.php
+++ b/AkismetPlugin.inc.php
@@ -13,7 +13,6 @@
  */
 
 import('lib.pkp.classes.plugins.GenericPlugin');
-use PKP\i18n;
 class AkismetPlugin extends GenericPlugin {
 	
 	/**

--- a/version.xml
+++ b/version.xml
@@ -12,8 +12,8 @@
 <version>
 	<application>akismet</application>
 	<type>plugins.generic</type>
-	<release>1.2.3.1</release>
-	<date>2023-08-24</date>
+	<release>1.2.3.2</release>
+	<date>2024-07-09</date>
 	<lazy-load>1</lazy-load>
 	<class>AkismetPlugin</class>
 </version>


### PR DESCRIPTION
Many notices related to: only variables should be assigned or passed by reference

260 appears to just have been a typo

Notice notwithstanding: 180/181 didn't appear to work with the explode and array pop passing through the locale string unchanged. The comment says we're looking for the first part of the locale (eg. the 'en' in 'en_US'). 